### PR TITLE
Add npmignore to whittle down the dist size

### DIFF
--- a/cubism-react/.npmignore
+++ b/cubism-react/.npmignore
@@ -1,0 +1,3 @@
+.storybook
+demos
+docs


### PR DESCRIPTION
We don't need to ship demos, docs, etc in the npm package