### PR TITLE
Keep CubismGraph rows in the same order as the original data

### DIFF
--- a/cubism-react/demos/static_data/index.js
+++ b/cubism-react/demos/static_data/index.js
@@ -24,7 +24,7 @@ const dates = Immutable.List(
   )
 );
 
-const series = Immutable.Map({
+const series = Immutable.OrderedMap({
   PRN1: new TimeseriesGenerator(100, -100),
   PRN2: { generate: (i) => Math.sin(i / 100) * 100 },
 });

--- a/cubism-react/demos/streaming/index.js
+++ b/cubism-react/demos/streaming/index.js
@@ -16,8 +16,8 @@ import TimeseriesGenerator from "../common/TimeseriesGenerator";
 type Props = {||};
 
 type State = {|
-  data: Immutable.Map<string, Immutable.OrderedMap<QuantizableDateRecord, Immutable.List<number>>>,
-  series: Immutable.Map<string, { generate: (number) => number }>,
+  data: Immutable.OrderedMap<string, Immutable.OrderedMap<QuantizableDateRecord, Immutable.List<number>>>,
+  series: Immutable.OrderedMap<string, { generate: (number) => number }>,
   dates: Immutable.List<QuantizableDateRecord>,
   dateMin: QuantizableDateRecord,
   dateMax: QuantizableDateRecord,
@@ -28,7 +28,7 @@ type State = {|
 class Wrapper extends React.Component<Props, State> {
   state: State = {
     data: Immutable.OrderedMap(),
-    series: Immutable.Map(),
+    series: Immutable.OrderedMap(),
     dates: Immutable.List(),
     dateMin: new QuantizableDateRecord(),
     dateMax: new QuantizableDateRecord(),
@@ -47,7 +47,7 @@ class Wrapper extends React.Component<Props, State> {
       )
     );
     
-    const series = Immutable.Map({
+    const series = Immutable.OrderedMap({
       PRN1: new TimeseriesGenerator(100, -100),
       PRN2: { generate: (i) => Math.sin(i / 100) * 100 },
     });

--- a/cubism-react/dist/CubismDataSourceStatic.react.js.flow
+++ b/cubism-react/dist/CubismDataSourceStatic.react.js.flow
@@ -10,7 +10,7 @@ import CubismDataContext, { Data } from "./CubismDataContext";
 import CubismLayoutContext, { Layout } from "./CubismLayoutContext";
 type Props = {|
   children: React.Node,
-  data: Immutable.Map<string, Immutable.OrderedMap<QuantizableDateRecord, Immutable.List<number>>>,
+  data: Immutable.OrderedMap<string, Immutable.OrderedMap<QuantizableDateRecord, Immutable.List<number>>>,
   dataMin: number,
   dataMax: number,
   dates: Immutable.List<QuantizableDateRecord>,

--- a/cubism-react/dist/types.js.flow
+++ b/cubism-react/dist/types.js.flow
@@ -7,5 +7,5 @@ export type ReactObjectRef<T: React.ElementType> = {|
 |};
 export type SamplesUnbucketed = Immutable.OrderedMap<QuantizableDateRecord, Immutable.List<number>>;
 export type SamplesBucketed = Immutable.OrderedMap<QuantizableDateRecord, number>;
-export type DataUnbucketed = Immutable.Map<string, SamplesUnbucketed>;
-export type DataBucketed = Immutable.Map<string, SamplesBucketed>;
+export type DataUnbucketed = Immutable.OrderedMap<string, SamplesUnbucketed>;
+export type DataBucketed = Immutable.OrderedMap<string, SamplesBucketed>;

--- a/cubism-react/src/CubismDataSourceStatic.react.js
+++ b/cubism-react/src/CubismDataSourceStatic.react.js
@@ -14,7 +14,7 @@ import CubismLayoutContext, { Layout } from "./CubismLayoutContext";
 
 type Props = {|
   children: React.Node,
-  data: Immutable.Map<
+  data: Immutable.OrderedMap<
     string,
     Immutable.OrderedMap<QuantizableDateRecord, Immutable.List<number>>
   >,

--- a/cubism-react/src/types.js
+++ b/cubism-react/src/types.js
@@ -16,5 +16,5 @@ export type SamplesUnbucketed = Immutable.OrderedMap<
 >;
 export type SamplesBucketed = Immutable.OrderedMap<QuantizableDateRecord, number>;
 
-export type DataUnbucketed = Immutable.Map<string, SamplesUnbucketed>;
-export type DataBucketed = Immutable.Map<string, SamplesBucketed>;
+export type DataUnbucketed = Immutable.OrderedMap<string, SamplesUnbucketed>;
+export type DataBucketed = Immutable.OrderedMap<string, SamplesBucketed>;


### PR DESCRIPTION
Make DataUnbucketed & DataBucketed OrderedMap so as to keep the ordering of timeseries when rendered